### PR TITLE
updating to Yrs 0.16.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,8 @@ Copyright (c) 2023
   - Kevin Jahns <kevin.jahns@pm.me>
   - Bartosz Sypytkowski <b.sypytkowski@gmail.com>
   - Hannes Moser <box@hannesmoser.at>
-  - Aidar Nugmanoff <a.nugmanoff@gmail.com
+  - Aidar Nugmanoff <a.nugmanoff@gmail.com>
+  - Joseph Heck <heckj@mac.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,10 +16,10 @@ members = [
 ]
 
 [dependencies]
-lib0 = "0.16.1" # must match yrs version
+lib0 = "0.16.2" # must match yrs version
 thiserror = "1.0.38"
 uniffi = "0.23.0"
-yrs = "0.16.1"
+yrs = "0.16.2"
 
 [build-dependencies]
 uniffi = { version = "0.23.0", features = [ "build" ] }


### PR DESCRIPTION
minor update shifting us forward to match Yrs, which updated to 0.16.2 last week. Not super-critical to use at the moment, but wanted to keep up. 0.16.2 fixes an infinite loop issue in XmlText (https://github.com/y-crdt/y-crdt/issues/260)