### PR TITLE
advancing to Yrs 0.16.4

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,10 +16,10 @@ members = [
 ]
 
 [dependencies]
-lib0 = "0.16.3" # must match yrs version
+lib0 = "0.16.4" # must match yrs version
 thiserror = "1.0.38"
 uniffi = "0.23.0"
-yrs = "0.16.3"
+yrs = "0.16.4"
 
 [build-dependencies]
 uniffi = { version = "0.23.0", features = [ "build" ] }


### PR DESCRIPTION
- primarily for YText updates, but also a couple of panic resolutions and documentation updates internal to Yrs